### PR TITLE
feat(cli-gui): helpful rendering functions (terminal-size, cursor, fill-region, read-key)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,36 @@ It uses the Cursor from the Symfony Command module.
 
 ### Functions
 
+#### Input
+
 - `(read-input [length])`: reads the input stream and returns it in different formats; `:raw` and `:hex`.
+- `(read-key)`: reads one key press and returns `:up`, `:down`, `:left`, `:right`, `:enter`, `:escape`, `:tab`, `:backspace`, or `{:char c}`.
+- `(parse-key [input-map])`: pure helper that maps a `read-input` result to the same key keywords.
+
+#### Terminal info
+
+- `(terminal-size)`: returns the current terminal dimensions as `{:width w :height h}`.
+- `(max-bounds)`: returns the max `(x,y)` extent reached by render/draw operations as `{:width w :height h}`.
+
+#### Cursor
+
+- `(hide-cursor)`: hides the terminal cursor.
+- `(show-cursor)`: shows the terminal cursor (hidden by default after init).
+
+#### Clearing
+
 - `(clear-screen)`: clears the entire screen.
-- `(clear-output)`: clears all the output from the cursors' current position to the end of the screen.
+- `(clear-output)`: clears all the output from the cursor's current position to the end of the screen.
 - `(clear-line [line])`: clears the output from the line.
-- `(render-board [{:width w :height h}])`: renders the borders of a board.
+
+#### Rendering
+
 - `(render [x y text & [style]])`: render any text to a concrete position (x,y) in the terminal.
 - `(render-text-block [x y text & [style]])`: render multiline strings without managing line offsets manually.
+- `(render-board [{:width w :height h} & [border-style]])`: renders the borders of a board.
 - `(draw-horizontal-line [x y length char & [style]])`: quickly draw separators or rulers.
 - `(draw-vertical-line [x y length char & [style]])`: draw vertical guides and columns.
+- `(fill-region [{:x x :y y :width w :height h :fill-char f}])`: paints an area with a fill character, without any border.
 - `(draw-box [{:x x :y y :width w :height h :border {:horizontal h :vertical v :corner c} :fill-char f}])`: draw framed areas with optional fill character.
 
 ### Example

--- a/src/phel/terminal-gui.phel
+++ b/src/phel/terminal-gui.phel
@@ -1,7 +1,8 @@
 (ns phel-cli-gui\terminal-gui
   (:use \PhelCliGui\TerminalGui)
   (:use \PhelCliGui\BorderStyle)
-  (:use \Symfony\Component\Console\Formatter\OutputFormatterStyle))
+  (:use \Symfony\Component\Console\Formatter\OutputFormatterStyle)
+  (:use \Symfony\Component\Console\Terminal))
 
 (defn- get-gui
   "Gets the singleton GUI instance."
@@ -36,6 +37,63 @@
   [length]
   (let [raw (php/fread php/STDIN length)]
     {:raw raw :hex (php/bin2hex raw)}))
+
+(defn parse-key
+  "Maps a read-input result to a key keyword or {:char raw}.
+  Known keys: :up :down :left :right :enter :escape :tab :backspace.
+  Empty input returns nil."
+  {:example "(parse-key {:raw \"\\r\" :hex \"0d\"}) ; => :enter"
+   :see-also ["read-key" "read-input"]}
+  [{:keys [raw hex]}]
+  (case hex
+    "" nil
+    "1b5b41" :up
+    "1b5b42" :down
+    "1b5b43" :right
+    "1b5b44" :left
+    "0d" :enter
+    "0a" :enter
+    "1b" :escape
+    "09" :tab
+    "7f" :backspace
+    "08" :backspace
+    {:char raw}))
+
+(defn read-key
+  "Reads one key press from stdin and returns a key keyword or {:char c}.
+  Returns nil when no input is available. See parse-key for the key set."
+  {:see-also ["parse-key" "read-input"]}
+  []
+  (parse-key (read-input 3)))
+
+(defn terminal-size
+  "Returns the current terminal dimensions as {:width w :height h}."
+  {:example "(terminal-size) ; => {:width 120 :height 40}"}
+  []
+  (let [term (php/new Terminal)]
+    {:width (php/-> term (getWidth))
+     :height (php/-> term (getHeight))}))
+
+(defn max-bounds
+  "Returns the maximum (x,y) extent reached by render/draw operations
+  on the current GUI instance as {:width w :height h}."
+  {:see-also ["render" "draw-box"]}
+  []
+  (let [gui (get-gui)]
+    {:width (php/-> gui (getMaxWidth))
+     :height (php/-> gui (getMaxHeight))}))
+
+(defn hide-cursor
+  "Hides the terminal cursor."
+  {:see-also ["show-cursor"]}
+  []
+  (gui-call (hideCursor)))
+
+(defn show-cursor
+  "Shows the terminal cursor (hidden by default after init)."
+  {:see-also ["hide-cursor"]}
+  []
+  (gui-call (showCursor)))
 
 (defn clear-screen
   "Clears the entire screen."
@@ -96,10 +154,18 @@
   ([x y length char style]
    (gui-call (drawVerticalLine x y length char style))))
 
+(defn fill-region
+  "Paints an area with a fill character, without any border."
+  {:example "(fill-region {:x 0 :y 0 :width 10 :height 3 :fill-char \".\"})"
+   :see-also ["draw-box" "clear-output"]}
+  [{:keys [x y width height fill-char]
+    :or {fill-char \space}}]
+  (gui-call (fillRegion x y width height fill-char)))
+
 (defn draw-box
   "Draw a box at a given position with optional fill and border styles."
   {:example "(draw-box {:x 0 :y 0 :width 10 :height 5 :fill-char \".\"})"
-   :see-also ["render-board" "draw-horizontal-line" "draw-vertical-line"]}
+   :see-also ["render-board" "fill-region" "draw-horizontal-line" "draw-vertical-line"]}
   [{:keys [x y width height border fill-char]
     :or {fill-char \space}}]
   (gui-call (drawBox x y width height (make-border-style border) fill-char)))

--- a/src/php/TerminalGui.php
+++ b/src/php/TerminalGui.php
@@ -7,7 +7,7 @@ namespace PhelCliGui;
 use Symfony\Component\Console\Cursor;
 use Symfony\Component\Console\Formatter\OutputFormatterStyleInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
-use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 final class TerminalGui
 {
@@ -23,7 +23,7 @@ final class TerminalGui
 
     public static function withStream(
         $inputStream = STDIN,
-        ?ConsoleOutputInterface $output = null,
+        ?OutputInterface $output = null,
         ?Cursor $cursor = null,
         bool $registerShutdownHandlers = true,
     ): self {
@@ -53,7 +53,7 @@ final class TerminalGui
      */
     private function __construct(
         private $inputStream,
-        private readonly ConsoleOutputInterface $output,
+        private readonly OutputInterface $output,
         private readonly Cursor $cursor,
         private string|null|false $sttyMode,
     ) {
@@ -88,6 +88,16 @@ final class TerminalGui
     public function clearScreen(): void
     {
         $this->cursor->clearScreen();
+    }
+
+    public function hideCursor(): void
+    {
+        $this->cursor->hide();
+    }
+
+    public function showCursor(): void
+    {
+        $this->cursor->show();
     }
 
     public function clearLine(int $line): void
@@ -141,6 +151,26 @@ final class TerminalGui
             $this->write($segment, $style);
         }
         $this->updateBoundsForArea($column, $row, 1, $length);
+        $this->finalizeCursor();
+    }
+
+    public function fillRegion(
+        int $column,
+        int $row,
+        int $width,
+        int $height,
+        string $fillChar = ' ',
+    ): void {
+        if ($width < 1 || $height < 1) {
+            throw new \InvalidArgumentException('Region width and height must be at least 1.');
+        }
+
+        $line = TerminalCanvas::horizontalLine($width, $fillChar);
+        for ($offset = 0; $offset < $height; $offset++) {
+            $this->cursor->moveToPosition($column, $row + $offset);
+            $this->write($line);
+        }
+        $this->updateBoundsForArea($column, $row, $width, $height);
         $this->finalizeCursor();
     }
 

--- a/tests/phel/terminal-gui-test.phel
+++ b/tests/phel/terminal-gui-test.phel
@@ -1,7 +1,8 @@
 (ns phel-cli-gui-test\terminal-gui-test
-  (:require phel\test :refer [deftest is]))
+  (:require phel\test :refer [deftest is testing])
+  (:require phel-cli-gui\terminal-gui :refer [parse-key]))
 
-# Test data structures and parameter validation without calling GUI functions
+;; Data structure and parameter validation tests (no GUI side effects).
 
 (deftest test-read-input-structure
   (let [test-input {:raw "test" :hex "74657374"}]
@@ -28,3 +29,34 @@
     (is (= "red" (:foreground formatter-config)))
     (is (= "blue" (:background formatter-config)))
     (is (= ["bold" "underscore"] (:options formatter-config)))))
+
+(deftest test-fill-region-config-structure
+  (let [region {:x 1 :y 2 :width 8 :height 3 :fill-char "."}]
+    (is (= 1 (:x region)))
+    (is (= 2 (:y region)))
+    (is (= 8 (:width region)))
+    (is (= 3 (:height region)))
+    (is (= "." (:fill-char region)))))
+
+(deftest test-parse-key-empty-input-returns-nil
+  (is (nil? (parse-key {:raw "" :hex ""}))))
+
+(deftest test-parse-key-recognises-arrow-keys
+  (testing "arrow keys"
+           (is (= :up    (parse-key {:raw "\e[A" :hex "1b5b41"})))
+           (is (= :down  (parse-key {:raw "\e[B" :hex "1b5b42"})))
+           (is (= :right (parse-key {:raw "\e[C" :hex "1b5b43"})))
+           (is (= :left  (parse-key {:raw "\e[D" :hex "1b5b44"})))))
+
+(deftest test-parse-key-recognises-control-keys
+  (testing "control keys"
+           (is (= :enter     (parse-key {:raw "\r"  :hex "0d"})))
+           (is (= :enter     (parse-key {:raw "\n"  :hex "0a"})))
+           (is (= :escape    (parse-key {:raw "\e"  :hex "1b"})))
+           (is (= :tab       (parse-key {:raw "\t"  :hex "09"})))
+           (is (= :backspace (parse-key {:raw ""    :hex "7f"})))
+           (is (= :backspace (parse-key {:raw ""    :hex "08"})))))
+
+(deftest test-parse-key-falls-back-to-char
+  (is (= {:char "a"} (parse-key {:raw "a" :hex "61"})))
+  (is (= {:char "Z"} (parse-key {:raw "Z" :hex "5a"}))))

--- a/tests/php/TerminalGuiTest.php
+++ b/tests/php/TerminalGuiTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelCliGui\Tests;
+
+use InvalidArgumentException;
+use PhelCliGui\TerminalGui;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Cursor;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class TerminalGuiTest extends TestCase
+{
+    private BufferedOutput $output;
+
+    /** @var resource */
+    private $inputStream;
+
+    private TerminalGui $gui;
+
+    protected function setUp(): void
+    {
+        $this->output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+        $this->inputStream = fopen('php://memory', 'rb');
+
+        $this->gui = TerminalGui::withStream(
+            inputStream: $this->inputStream,
+            output: $this->output,
+            cursor: new Cursor($this->output),
+            registerShutdownHandlers: false,
+        );
+
+        // Drain the init output (cursor hide + move-to-origin).
+        $this->output->fetch();
+    }
+
+    protected function tearDown(): void
+    {
+        TerminalGui::resetInstance();
+        if (is_resource($this->inputStream)) {
+            fclose($this->inputStream);
+        }
+    }
+
+    public function test_fill_region_writes_one_row_per_line_with_fill_char(): void
+    {
+        $this->gui->fillRegion(0, 0, 4, 3, '.');
+
+        self::assertSame(3, substr_count($this->output->fetch(), '....'));
+    }
+
+    public function test_fill_region_updates_max_bounds(): void
+    {
+        $this->gui->fillRegion(2, 1, 5, 3, '#');
+
+        self::assertSame(2 + 5 - 1, $this->gui->getMaxWidth());
+        self::assertSame(1 + 3 - 1, $this->gui->getMaxHeight());
+    }
+
+    public function test_fill_region_rejects_zero_or_negative_dimensions(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Region width and height must be at least 1.');
+
+        $this->gui->fillRegion(0, 0, 0, 1);
+    }
+
+    public function test_hide_cursor_emits_ansi_hide_sequence(): void
+    {
+        $this->gui->hideCursor();
+
+        self::assertStringContainsString("\033[?25l", $this->output->fetch());
+    }
+
+    public function test_show_cursor_emits_ansi_show_sequence(): void
+    {
+        $this->gui->showCursor();
+
+        self::assertStringContainsString("\033[?25h", $this->output->fetch());
+    }
+
+    public function test_render_writes_text_at_requested_position(): void
+    {
+        $this->gui->render(3, 2, 'hello');
+
+        $content = $this->output->fetch();
+
+        // Symfony Cursor::moveToPosition(col, row) emits "\e[{row+1};{col}H".
+        self::assertStringContainsString("\033[3;3H", $content);
+        self::assertStringContainsString('hello', $content);
+    }
+
+    public function test_render_tracks_max_bounds_using_display_width(): void
+    {
+        $this->gui->render(0, 0, 'abc');
+        self::assertSame(2, $this->gui->getMaxWidth());
+        self::assertSame(0, $this->gui->getMaxHeight());
+
+        $this->gui->render(10, 5, 'x');
+        self::assertSame(10, $this->gui->getMaxWidth());
+        self::assertSame(5, $this->gui->getMaxHeight());
+    }
+
+    public function test_render_text_block_splits_on_newlines(): void
+    {
+        $this->gui->renderTextBlock(0, 0, "line-1\nline-2\nline-3");
+
+        $content = $this->output->fetch();
+        self::assertStringContainsString('line-1', $content);
+        self::assertStringContainsString('line-2', $content);
+        self::assertStringContainsString('line-3', $content);
+        self::assertSame(2, $this->gui->getMaxHeight());
+    }
+
+    public function test_draw_vertical_line_rejects_zero_length(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->gui->drawVerticalLine(0, 0, 0, '|');
+    }
+
+    public function test_draw_vertical_line_updates_bounds_for_column(): void
+    {
+        $this->gui->drawVerticalLine(4, 0, 6, '|');
+
+        self::assertSame(4, $this->gui->getMaxWidth());
+        self::assertSame(5, $this->gui->getMaxHeight());
+    }
+
+    public function test_render_board_uses_default_border_style_at_origin(): void
+    {
+        $this->gui->renderBoard(4, 3);
+
+        $content = $this->output->fetch();
+        self::assertStringContainsString('+--+', $content);
+        self::assertStringContainsString('|  |', $content);
+    }
+}


### PR DESCRIPTION
## Summary

Adds five new primitives that fill gaps for terminal-GUI developers:

- `(terminal-size)` — current dimensions as `{:width w :height h}` via `Symfony\Console\Terminal`
- `(hide-cursor)` / `(show-cursor)` — toggle cursor visibility after init (useful for inline prompts / animations)
- `(max-bounds)` — exposes the instance's render/draw extent as `{:width w :height h}`
- `(fill-region {:x :y :width :height :fill-char})` — paint an area without a border
- `(read-key)` + pure `(parse-key)` — map stdin escape sequences to `:up/:down/:left/:right/:enter/:escape/:tab/:backspace` or `{:char c}`

## Changes

- **Phel** (`src/phel/terminal-gui.phel`): new functions, grouped by concern (input / terminal info / cursor / clearing / rendering), all with `{:example …}` / `{:see-also …}` metadata.
- **PHP** (`src/php/TerminalGui.php`): new `hideCursor`, `showCursor`, `fillRegion` methods; `withStream(...)` now accepts `OutputInterface` instead of `ConsoleOutputInterface` — the narrower hint was unnecessary and blocked `BufferedOutput`-based tests.
- **README**: reorganised function docs into logical groups.
