### PR TITLE
ci: add GitHub Actions build & test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Build & test (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.4', '8.5']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: pcntl, posix, readline
+          coverage: none
+          tools: composer:v2
+
+      - name: Validate composer.json
+        run: composer validate --strict
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: composer-${{ matrix.php }}-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-${{ matrix.php }}-
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Build
+        run: composer build
+
+      - name: Test
+        run: composer test


### PR DESCRIPTION
## Summary

Adds CI — the repo had no workflows, so PRs merged without automated checks.

Runs on every push to `main` and every PR:
- `composer validate --strict`
- `composer build`
- `composer test` (Phel + PHPUnit)

Matrix: PHP 8.4 and 8.5. Extensions: pcntl, posix, readline. Composer deps cached.

## Test plan
- `composer validate --strict`, `composer build`, `composer test` all pass locally.