### PR TITLE
chore: optimize phel-config with forProject convenience constructor

### DIFF
--- a/phel-config.php
+++ b/phel-config.php
@@ -2,12 +2,8 @@
 
 declare(strict_types=1);
 
-use Phel\Config\PhelBuildConfig;
 use Phel\Config\PhelConfig;
 use Phel\Config\ProjectLayout;
 
-return (new PhelConfig())
-    ->withLayout(ProjectLayout::Nested)
-    ->withBuildConfig((new PhelBuildConfig())
-        ->withMainPhpPath('out/main.php')
-        ->withMainPhelNamespace('phel-cli-gui.terminal-gui'));
+return PhelConfig::forProject(ProjectLayout::Nested, 'phel-cli-gui.terminal-gui')
+    ->withMainPhpPath('out/main.php');


### PR DESCRIPTION
## Summary

Simplifies `phel-config.php` using the `PhelConfig::forProject` convenience constructor (phel 0.44), which sets layout + main namespace in one call. Drops the `PhelBuildConfig` import and nested builder.

```php
return PhelConfig::forProject(ProjectLayout::Nested, 'phel-cli-gui.terminal-gui')
    ->withMainPhpPath('out/main.php');
```

## Test plan
- `composer build` produces `out/main.php` with the `phel_cli_gui/terminal_gui` namespace.
- `composer test` green (18 Phel + 37 PHPUnit).