### PR TITLE
perf: avoid eager fallback-map alloc in parse-key

### DIFF
--- a/src/phel/terminal-gui.phel
+++ b/src/phel/terminal-gui.phel
@@ -52,7 +52,7 @@
    :see-also ["read-key" "read-input"]}
   [{:keys [raw hex]}]
   (when-not (empty? hex)
-    (get key-map hex {:char raw})))
+    (or (get key-map hex) {:char raw})))
 
 (defn read-key
   "Reads one key press from stdin and returns a key keyword or {:char c}.


### PR DESCRIPTION
## Summary

`(get key-map hex {:char raw})` evaluates its fallback argument eagerly, allocating the `{:char raw}` map on **every** `parse-key` call — including known-key hits (arrows/enter, the common input-loop case).

`key-map` values are all keywords (always truthy), so `(or (get key-map hex) {:char raw})` returns the keyword on a hit and only allocates the fallback on the miss path (printable chars).

### Scope note
`terminal-gui.phel` is a thin binding over Symfony's cursor; the dominant runtime cost is PHP-side stdout/ANSI writes, not Phel dispatch. This is the one phel-level allocation worth removing. The larger perf lever (batching draws into a single per-frame flush) lives in `TerminalGui.php`, out of this file's scope.

## Test plan
- `composer build` clean.
- `composer test` green; existing `parse-key` tests cover hit / miss / multibyte / unknown-escape.