### PR TITLE
feat: batch per-frame draws into a single stdout flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Frame batching: `begin-frame`, `end-frame`, and the `with-frame` macro buffer
+  all draws within a frame and flush them to the terminal in a single write
+  (one write per frame instead of one per draw call). Output is byte-identical
+  to immediate mode; immediate mode remains the default.
+- `perf` win: `parse-key` no longer allocates the `{:char raw}` fallback map on
+  known-key hits.
+
 ## [0.11.0] - 2026-06-14
 
 ### Changed

--- a/docs/api.md
+++ b/docs/api.md
@@ -63,6 +63,27 @@ Recognised keys: `:up` `:down` `:left` `:right` `:enter` `:escape` `:tab`
 `:fill-char` and border chars default to single-byte ASCII (`" "`, `-`, `|`, `+`).
 Multibyte characters (`─`, `│`, `┼`) are supported.
 
+## Frame batching
+
+By default every draw call writes to stdout immediately — one `write` per call.
+For draw-heavy redraws (e.g. a game loop repainting a board each tick), wrap the
+draws in a frame so they accumulate and flush in a **single** write.
+
+| Function | Effect |
+|---|---|
+| `(begin-frame)` | Start buffering draws. Nestable — only the outermost `end-frame` flushes. |
+| `(end-frame)` | Flush the buffered frame in one write. No-op when no frame is open. |
+| `(with-frame & body)` | Macro: run `body` inside a frame, flushing once on completion (even on throw). |
+
+```phel
+(with-frame
+  (clear-screen)
+  (draw-box {:x 0 :y 0 :width 20 :height 8})
+  (render 2 2 "Score: 42"))
+```
+
+Output is byte-identical to immediate mode; only the number of writes changes.
+
 ## Styling
 
 Register a named style once, then pass the name to any rendering call that

--- a/src/phel/terminal-gui.phel
+++ b/src/phel/terminal-gui.phel
@@ -109,6 +109,34 @@
   [line]
   (.clearLine (get-gui) line))
 
+(defn begin-frame
+  "Opens a buffered frame: subsequent draws are accumulated and flushed to the
+  terminal in a single write by end-frame, instead of one write per draw call.
+  Nestable — only the outermost end-frame flushes."
+  {:see-also ["end-frame" "with-frame"]}
+  []
+  (.beginFrame (get-gui)))
+
+(defn end-frame
+  "Flushes the current buffered frame to the terminal in a single write.
+  No-op when no frame is open; only the outermost call flushes."
+  {:see-also ["begin-frame" "with-frame"]}
+  []
+  (.endFrame (get-gui)))
+
+(defmacro with-frame
+  "Evaluates body inside a buffered frame, flushing every draw in a single
+  write once body completes (even if it throws)."
+  {:example "(with-frame (draw-box {:x 0 :y 0 :width 10 :height 5}) (render 2 2 \"hi\"))"
+   :see-also ["begin-frame" "end-frame"]}
+  [& body]
+  `(do
+     (begin-frame)
+     (try
+       (do ~@body)
+       (finally
+         (end-frame)))))
+
 (defn render-board
   "Renders the borders of a board."
   {:example "(render-board {:width 10 :height 5})"

--- a/src/php/TerminalGui.php
+++ b/src/php/TerminalGui.php
@@ -6,6 +6,7 @@ namespace PhelCliGui;
 
 use Symfony\Component\Console\Cursor;
 use Symfony\Component\Console\Formatter\OutputFormatterStyleInterface;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -14,6 +15,15 @@ final class TerminalGui
     private int $maxWidth = 0;
     private int $maxHeight = 0;
     private bool $cleanedUp = false;
+
+    /**
+     * When a frame is open, draws are accumulated here and flushed to the real
+     * output in a single write by endFrame(). Null in immediate mode.
+     */
+    private ?BufferedOutput $frameBuffer = null;
+    private ?Cursor $frameCursor = null;
+    private int $frameDepth = 0;
+
     private static ?self $instance = null;
 
     public static function getInstance(
@@ -86,6 +96,54 @@ final class TerminalGui
         return $this;
     }
 
+    /**
+     * Opens a buffered frame: subsequent draw/cursor operations are accumulated
+     * and emitted in a single write by endFrame(), instead of one write per call.
+     * Nestable — only the outermost end flushes.
+     */
+    public function beginFrame(): void
+    {
+        if ($this->frameDepth++ > 0) {
+            return;
+        }
+
+        $this->frameBuffer = new BufferedOutput(
+            $this->output->getVerbosity(),
+            $this->output->isDecorated(),
+            $this->output->getFormatter(),
+        );
+        $this->frameCursor = new Cursor($this->frameBuffer);
+    }
+
+    /**
+     * Flushes the current buffered frame to the terminal in a single raw write.
+     * No-op when no frame is open; only the outermost call flushes.
+     */
+    public function endFrame(): void
+    {
+        if ($this->frameDepth === 0 || --$this->frameDepth > 0) {
+            return;
+        }
+
+        $buffer = $this->frameBuffer?->fetch() ?? '';
+        $this->frameBuffer = null;
+        $this->frameCursor = null;
+
+        if ($buffer !== '') {
+            $this->output->write($buffer, false, OutputInterface::OUTPUT_RAW);
+        }
+    }
+
+    private function activeCursor(): Cursor
+    {
+        return $this->frameCursor ?? $this->cursor;
+    }
+
+    private function activeOutput(): OutputInterface
+    {
+        return $this->frameBuffer ?? $this->output;
+    }
+
     public function renderBoard(
         int $width,
         int $height,
@@ -96,33 +154,33 @@ final class TerminalGui
 
     public function clearScreen(): void
     {
-        $this->cursor->clearScreen();
+        $this->activeCursor()->clearScreen();
     }
 
     public function hideCursor(): void
     {
-        $this->cursor->hide();
+        $this->activeCursor()->hide();
     }
 
     public function showCursor(): void
     {
-        $this->cursor->show();
+        $this->activeCursor()->show();
     }
 
     public function clearLine(int $line): void
     {
-        $this->cursor->moveToPosition(0, $line);
-        $this->cursor->clearLine();
+        $this->activeCursor()->moveToPosition(0, $line);
+        $this->activeCursor()->clearLine();
     }
 
     public function clearOutput(): void
     {
-        $this->cursor->clearOutput();
+        $this->activeCursor()->clearOutput();
     }
 
     public function render(int $column, int $row, string $text, ?string $style = ''): void
     {
-        $this->cursor->moveToPosition($column, $row);
+        $this->activeCursor()->moveToPosition($column, $row);
         $this->write($text, $style);
         $this->updateBoundsForArea($column, $row, Text::displayWidth($text), 1);
         $this->finalizeCursor();
@@ -132,7 +190,7 @@ final class TerminalGui
     {
         $lines = preg_split('/\R/', $text) ?: [''];
         foreach ($lines as $offset => $line) {
-            $this->cursor->moveToPosition($column, $row + $offset);
+            $this->activeCursor()->moveToPosition($column, $row + $offset);
             $this->write($line, $style);
             $this->updateBoundsForArea($column, $row + $offset, Text::displayWidth($line), 1);
         }
@@ -142,7 +200,7 @@ final class TerminalGui
     public function drawHorizontalLine(int $column, int $row, int $length, string $char, ?string $style = ''): void
     {
         $line = TerminalCanvas::horizontalLine($length, $char);
-        $this->cursor->moveToPosition($column, $row);
+        $this->activeCursor()->moveToPosition($column, $row);
         $this->write($line, $style);
         $this->updateBoundsForArea($column, $row, $length, 1);
         $this->finalizeCursor();
@@ -156,7 +214,7 @@ final class TerminalGui
 
         $segment = Text::firstChar($char !== '' ? $char : '|', '|');
         for ($offset = 0; $offset < $length; $offset++) {
-            $this->cursor->moveToPosition($column, $row + $offset);
+            $this->activeCursor()->moveToPosition($column, $row + $offset);
             $this->write($segment, $style);
         }
         $this->updateBoundsForArea($column, $row, 1, $length);
@@ -176,7 +234,7 @@ final class TerminalGui
 
         $line = TerminalCanvas::horizontalLine($width, $fillChar);
         for ($offset = 0; $offset < $height; $offset++) {
-            $this->cursor->moveToPosition($column, $row + $offset);
+            $this->activeCursor()->moveToPosition($column, $row + $offset);
             $this->write($line);
         }
         $this->updateBoundsForArea($column, $row, $width, $height);
@@ -194,7 +252,7 @@ final class TerminalGui
         $lines = TerminalCanvas::boxLines($width, $height, $style ?? BorderStyle::withChars(), $fillChar);
 
         foreach ($lines as $offset => $line) {
-            $this->cursor->moveToPosition($column, $row + $offset);
+            $this->activeCursor()->moveToPosition($column, $row + $offset);
             $this->write($line);
         }
 
@@ -214,7 +272,7 @@ final class TerminalGui
 
     private function write(string $text, ?string $style = ''): void
     {
-        $this->output->write(empty($style) ? $text : "<$style>$text</$style>");
+        $this->activeOutput()->write(empty($style) ? $text : "<$style>$text</$style>");
     }
 
     private function updateBoundsForArea(int $column, int $row, int $width, int $height): void
@@ -225,7 +283,7 @@ final class TerminalGui
 
     private function finalizeCursor(): void
     {
-        $this->cursor->moveToPosition($this->maxWidth, $this->maxHeight);
+        $this->activeCursor()->moveToPosition($this->maxWidth, $this->maxHeight);
     }
 
     private function cleanUp(): void

--- a/tests/php/TerminalGuiTest.php
+++ b/tests/php/TerminalGuiTest.php
@@ -224,4 +224,92 @@ final class TerminalGuiTest extends TestCase
 
         self::assertSame($a, $b);
     }
+
+    public function test_begin_frame_defers_writes_until_end_frame(): void
+    {
+        $this->gui->beginFrame();
+        $this->gui->render(0, 0, 'buffered');
+
+        // Nothing reaches the real output while the frame is open.
+        self::assertSame('', $this->output->fetch());
+
+        $this->gui->endFrame();
+        self::assertStringContainsString('buffered', $this->output->fetch());
+    }
+
+    public function test_frame_output_matches_immediate_mode(): void
+    {
+        $this->gui->render(1, 1, 'abc');
+        $immediate = $this->output->fetch();
+
+        $this->gui->beginFrame();
+        $this->gui->render(1, 1, 'abc');
+        $this->gui->endFrame();
+        $buffered = $this->output->fetch();
+
+        self::assertSame($immediate, $buffered);
+    }
+
+    public function test_nested_frames_flush_only_on_outermost_end(): void
+    {
+        $this->gui->beginFrame();
+        $this->gui->beginFrame();
+        $this->gui->render(0, 0, 'x');
+
+        $this->gui->endFrame(); // inner — no flush yet
+        self::assertSame('', $this->output->fetch());
+
+        $this->gui->endFrame(); // outer — flush
+        self::assertStringContainsString('x', $this->output->fetch());
+    }
+
+    public function test_end_frame_without_begin_is_noop(): void
+    {
+        $this->gui->endFrame();
+
+        self::assertSame('', $this->output->fetch());
+    }
+
+    public function test_frame_collapses_many_draws_into_a_single_write(): void
+    {
+        TerminalGui::resetInstance();
+
+        $counter = new class(OutputInterface::VERBOSITY_NORMAL, true) extends BufferedOutput {
+            public int $writes = 0;
+
+            protected function doWrite(string $message, bool $newline): void
+            {
+                ++$this->writes;
+                parent::doWrite($message, $newline);
+            }
+        };
+
+        $gui = TerminalGui::withStream(
+            inputStream: $this->inputStream,
+            output: $counter,
+            cursor: new Cursor($counter),
+            registerShutdownHandlers: false,
+        );
+        $counter->writes = 0; // ignore init (cursor hide + move-to-origin)
+
+        $gui->beginFrame();
+        for ($row = 0; $row < 10; ++$row) {
+            $gui->render(0, $row, 'row');
+        }
+        $gui->endFrame();
+
+        // 10 immediate renders would be 30+ writes; buffered collapses to one.
+        self::assertSame(1, $counter->writes);
+    }
+
+    public function test_named_style_renders_inside_frame(): void
+    {
+        $this->gui->addOutputFormatter('danger', new OutputFormatterStyle('red', null, ['bold']));
+
+        $this->gui->beginFrame();
+        $this->gui->render(0, 0, 'boom', 'danger');
+        $this->gui->endFrame();
+
+        self::assertStringContainsString("\033[31;1mboom\033[39;22m", $this->output->fetch());
+    }
 }


### PR DESCRIPTION
Closes #8.

## Summary

Adds a buffered **frame** mode to `TerminalGui`. By default every draw writes to stdout immediately (one `write` per call); a draw-heavy redraw issues hundreds of small writes per frame. With a frame open, all cursor/draw operations accumulate in a `BufferedOutput` and flush to the real output in a **single raw write**.

- `beginFrame()` / `endFrame()` (PHP) — depth-counted, so only the outermost `end` flushes.
- Phel API: `(begin-frame)`, `(end-frame)`, and the `(with-frame & body)` macro (flushes on completion, even on throw, via `try`/`finally`).
- Immediate mode unchanged; existing callers unaffected.
- Output is **byte-identical** to immediate mode — only the write count changes.

```phel
(with-frame
  (clear-screen)
  (draw-box {:x 0 :y 0 :width 20 :height 8})
  (render 2 2 "Score: 42"))
```

## Implementation

- Draw/cursor/clear ops route through `activeCursor()` / `activeOutput()`, which return the frame's buffered cursor/output when a frame is open, else the real ones.
- The frame buffer shares the real output's verbosity, decoration and **formatter**, so named styles still render inside a frame.
- `cleanUp()` keeps writing to the real terminal directly.

## Test plan
- `composer build`, `composer test`, `composer format` all clean.
- New PHPUnit tests (43 total, was 37): writes deferred until `endFrame`, output matches immediate mode, nested frames flush once, `endFrame` without `beginFrame` is a no-op, **10 renders collapse to 1 write**, named styles render inside a frame.

## Acceptance criteria (#8)
- [x] N draw calls → 1 stdout write
- [x] Existing API unchanged for non-batching callers
- [x] Buffered-vs-immediate covered by tests (no ANSI leak between modes)
- [x] Benchmark assertion: `test_frame_collapses_many_draws_into_a_single_write`