### PR TITLE
docs(changelog): condense unreleased notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Frame batching: `begin-frame`, `end-frame`, and the `with-frame` macro buffer
-  all draws within a frame and flush them to the terminal in a single write
-  (one write per frame instead of one per draw call). Output is byte-identical
-  to immediate mode; immediate mode remains the default.
-- `perf` win: `parse-key` no longer allocates the `{:char raw}` fallback map on
-  known-key hits.
+- Frame batching (`begin-frame`, `end-frame`, `with-frame`): buffer a frame's draws into a single write.
+
+### Performance
+- `parse-key`: skip fallback-map allocation on known-key hits.
 
 ## [0.11.0] - 2026-06-14
 


### PR DESCRIPTION
Trim the Unreleased entries to one-liners; move the parse-key item under a Performance heading.