### PR TITLE
feat: 256-color, alt-screen, cursor & drain-input primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Frame batching (`begin-frame`, `end-frame`, `with-frame`): buffer a frame's draws into a single write.
+- 256-color & truecolor styles: `add-color` (`:fg-256`/`:bg-256`/`:fg-rgb`/`:bg-rgb`/`:options`) and the pure `color->sgr` helper.
+- Alternate screen: `enter-alt-screen`, `leave-alt-screen`, `with-screen` macro (also left on cleanup).
+- Cursor: `move-cursor`, `cursor-home` for flicker-free overwrite-in-place repaints.
+- Input: `read-available` drains all pending bytes in one read for held-key responsiveness.
 
 ### Performance
 - `parse-key`: skip fallback-map allocation on known-key hits.

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,6 +9,7 @@ All public functions live in `phel-cli-gui.terminal-gui`.
 | `(read-input length)` | Read up to `length` bytes from stdin. Returns `{:raw s :hex h}`. |
 | `(read-key)` | Read one keypress. Returns a keyword or `{:char c}` or `nil` when no input. |
 | `(parse-key input)` | Pure helper: map a `read-input` result to a keyword / `{:char c}`. |
+| `(read-available)` / `(read-available max-bytes)` | Drain all pending input bytes in one read (raw string, `""` when idle). For held-key responsiveness. |
 
 Recognised keys: `:up` `:down` `:left` `:right` `:enter` `:escape` `:tab`
 `:backspace`. Anything else becomes `{:char raw}`.
@@ -36,9 +37,37 @@ Recognised keys: `:up` `:down` `:left` `:right` `:enter` `:escape` `:tab`
 |---|---|
 | `(hide-cursor)` | Hide the caret. |
 | `(show-cursor)` | Show the caret. |
+| `(move-cursor x y)` | Move the caret to an absolute `(x, y)` without drawing. |
+| `(cursor-home)` | Move the caret to the origin `(0, 0)`. |
 
 > Cursor is hidden automatically on init; call `(cleanup-gui)` (or let the
 > shutdown handler fire) to restore it.
+
+Pair `(cursor-home)` with overwriting renders to repaint a frame in place —
+no flickering full `(clear-screen)` each tick.
+
+## Full-screen
+
+| Function | Effect |
+|---|---|
+| `(enter-alt-screen)` | Switch to the alternate screen buffer (scrollback preserved). Idempotent. |
+| `(leave-alt-screen)` | Return to the normal screen, restoring prior content. |
+| `(with-screen & body)` | Macro: run `body` on the alt screen with the cursor hidden, restoring both on exit (even on throw). |
+
+The alternate screen is also left automatically on `(cleanup-gui)` / shutdown,
+so a crash never strands the user on a blank page.
+
+```phel
+(with-screen
+  (loop []
+    (with-frame
+      (cursor-home)
+      (draw-box {:x 0 :y 0 :width 40 :height 12})
+      (render 2 2 "Press q to quit"))
+    (when-not (= {:char "q"} (read-key))
+      (php/usleep 16000)
+      (recur))))
+```
 
 ## Clearing
 
@@ -101,6 +130,29 @@ takes a `style` argument.
 
 `:options` accepts Symfony output options: `"bold"`, `"underscore"`,
 `"blink"`, `"reverse"`, `"conceal"`.
+
+### 256-color & truecolor
+
+For the full xterm-256 palette or 24-bit RGB, register a style with
+`add-color` and use it the same way:
+
+```phel
+(add-color {:style-name "lava"  :fg-256 196 :bg-256 52 :options ["bold"]})
+(add-color {:style-name "ocean" :fg-rgb [120 180 255]})
+
+(render 0 0 "molten" "lava")
+(render 0 1 "wave"   "ocean")
+```
+
+| Key | Value |
+|---|---|
+| `:fg-256` / `:bg-256` | xterm-256 palette index, `0`–`255`. |
+| `:fg-rgb` / `:bg-rgb` | `[r g b]`, each `0`–`255` (24-bit truecolor). |
+| `:options` | `"bold"` `"dim"` `"italic"` `"underline"` `"blink"` `"reverse"` `"conceal"` `"strikethrough"`. |
+
+`(color->sgr spec)` is the pure helper underneath — it returns the raw ANSI
+SGR parameter string (e.g. `"38;5;196;1"`) if you want to build sequences
+yourself.
 
 ## Lifecycle
 

--- a/src/phel/terminal-gui.phel
+++ b/src/phel/terminal-gui.phel
@@ -37,6 +37,47 @@
                                 background
                                 (to-php-array options))))
 
+(def- sgr-option-codes
+  {"bold"          "1"
+   "dim"           "2"
+   "italic"        "3"
+   "underline"     "4"
+   "underscore"    "4"
+   "blink"         "5"
+   "reverse"       "7"
+   "conceal"       "8"
+   "strikethrough" "9"})
+
+(defn- present? [x] (not (nil? x)))
+
+(defn- join-sgr [parts]
+  (reduce (fn [acc p] (if (= acc "") p (str acc ";" p))) "" parts))
+
+(defn color->sgr
+  "Pure helper: builds an ANSI SGR parameter string from a colour spec.
+  Accepts :fg-256/:bg-256 (0-255 xterm palette index), :fg-rgb/:bg-rgb
+  ([r g b]), and :options (e.g. [\"bold\" \"underline\"])."
+  {:example "(color->sgr {:fg-256 196 :options [\"bold\"]}) ; => \"38;5;196;1\""
+   :see-also ["add-color"]}
+  [{:keys [fg-256 bg-256 fg-rgb bg-rgb options]
+    :or {options []}}]
+  (let [color-parts (filter present?
+                            [(when fg-256 (str "38;5;" fg-256))
+                             (when bg-256 (str "48;5;" bg-256))
+                             (when fg-rgb (str "38;2;" (get fg-rgb 0) ";" (get fg-rgb 1) ";" (get fg-rgb 2)))
+                             (when bg-rgb (str "48;2;" (get bg-rgb 0) ";" (get bg-rgb 1) ";" (get bg-rgb 2)))])
+        opt-parts   (filter present? (map (fn [o] (get sgr-option-codes o)) options))]
+    (join-sgr (concat color-parts opt-parts))))
+
+(defn add-color
+  "Registers a named 256-colour / truecolor style usable in any render call,
+  exactly like a style from add-output-formatter. Takes the same colour keys
+  as color->sgr plus :style-name."
+  {:example "(add-color {:style-name \"lava\" :fg-256 196 :bg-256 52 :options [\"bold\"]})"
+   :see-also ["add-output-formatter" "color->sgr" "render"]}
+  [{:keys [style-name] :as spec}]
+  (.addAnsiStyle (get-gui) style-name (color->sgr spec)))
+
 (defn read-input
   "Reads the input stream and returns it in different formats."
   {:example "(read-input 3) ; => {:raw \"a\" :hex \"61\"}"}
@@ -60,6 +101,17 @@
   {:see-also ["parse-key" "read-input"]}
   []
   (parse-key (read-input 3)))
+
+(defn read-available
+  "Drains all currently-pending input bytes in one read and returns them as a
+  raw string (empty when nothing is pending). Lets a held key apply its motion
+  several times per frame instead of being throttled to one key per loop tick."
+  {:example "(read-available) ; => \"www\""
+   :see-also ["read-key" "read-input"]}
+  ([] (read-available 1024))
+  ([max-bytes]
+   (let [s (php/fread php/STDIN max-bytes)]
+     (if (= s false) "" s))))
 
 (defn terminal-size
   "Returns the current terminal dimensions as {:width w :height h}."
@@ -89,6 +141,20 @@
   {:see-also ["hide-cursor"]}
   []
   (.showCursor (get-gui)))
+
+(defn move-cursor
+  "Moves the cursor to an absolute (x, y) position without drawing."
+  {:example "(move-cursor 0 0)"
+   :see-also ["cursor-home" "render"]}
+  [x y]
+  (.moveCursor (get-gui) x y))
+
+(defn cursor-home
+  "Moves the cursor to the top-left origin (0, 0). Pair with overwriting
+  renders to repaint a frame in place without a flickering full clear."
+  {:see-also ["move-cursor" "clear-screen"]}
+  []
+  (.cursorHome (get-gui)))
 
 (defn clear-screen
   "Clears the entire screen."
@@ -136,6 +202,36 @@
        (do ~@body)
        (finally
          (end-frame)))))
+
+(defn enter-alt-screen
+  "Switches to the terminal's alternate screen buffer: a full-screen UI draws
+  on a fresh page and the user's scrollback is restored untouched on
+  leave-alt-screen (or cleanup-gui). Idempotent."
+  {:see-also ["leave-alt-screen" "with-screen"]}
+  []
+  (.enterAltScreen (get-gui)))
+
+(defn leave-alt-screen
+  "Leaves the alternate screen buffer, restoring the prior terminal content."
+  {:see-also ["enter-alt-screen" "with-screen"]}
+  []
+  (.leaveAltScreen (get-gui)))
+
+(defmacro with-screen
+  "Runs body on the alternate screen with the cursor hidden, restoring the
+  original screen and cursor on completion (even if body throws). Ideal for
+  full-screen apps and games."
+  {:example "(with-screen (clear-screen) (render 0 0 \"Hello\") (read-key))"
+   :see-also ["enter-alt-screen" "leave-alt-screen"]}
+  [& body]
+  `(do
+     (enter-alt-screen)
+     (hide-cursor)
+     (try
+       (do ~@body)
+       (finally
+         (show-cursor)
+         (leave-alt-screen)))))
 
 (defn render-board
   "Renders the borders of a board."

--- a/src/php/AnsiStyle.php
+++ b/src/php/AnsiStyle.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelCliGui;
+
+use Symfony\Component\Console\Formatter\OutputFormatterStyleInterface;
+
+/**
+ * An output-formatter style backed by a raw ANSI SGR parameter string
+ * (e.g. "38;5;196" for xterm-256 red, or "38;2;255;0;0" for truecolor).
+ *
+ * Symfony's built-in OutputFormatterStyle only speaks 4-bit names and
+ * #hex; this lets named styles carry full 256-colour / RGB sequences while
+ * still flowing through the existing formatter, so render bounds stay
+ * correct (the styled text the user sees never contains the escape bytes).
+ */
+final class AnsiStyle implements OutputFormatterStyleInterface
+{
+    public function __construct(private string $sgr)
+    {
+    }
+
+    public function setForeground(?string $color): void
+    {
+    }
+
+    public function setBackground(?string $color): void
+    {
+    }
+
+    public function setOption(string $option): void
+    {
+    }
+
+    public function unsetOption(string $option): void
+    {
+    }
+
+    public function setOptions(array $options): void
+    {
+    }
+
+    public function apply(string $text): string
+    {
+        if ($this->sgr === '') {
+            return $text;
+        }
+
+        return "\033[{$this->sgr}m{$text}\033[0m";
+    }
+}

--- a/src/php/TerminalGui.php
+++ b/src/php/TerminalGui.php
@@ -24,6 +24,9 @@ final class TerminalGui
     private ?Cursor $frameCursor = null;
     private int $frameDepth = 0;
 
+    /** Whether the alternate screen buffer is currently active. */
+    private bool $inAltScreen = false;
+
     private static ?self $instance = null;
 
     public static function getInstance(
@@ -94,6 +97,54 @@ final class TerminalGui
         $this->output->getFormatter()->setStyle($name, $style);
 
         return $this;
+    }
+
+    /**
+     * Registers a named style from a raw ANSI SGR parameter string, e.g.
+     * "38;5;196" (xterm-256) or "38;2;255;0;0" (truecolor). Usable in any
+     * render call exactly like a style added via addOutputFormatter().
+     */
+    public function addAnsiStyle(string $name, string $sgr): self
+    {
+        return $this->addOutputFormatter($name, new AnsiStyle($sgr));
+    }
+
+    /**
+     * Switches to the terminal's alternate screen buffer, so a full-screen UI
+     * draws on a fresh page and the user's scrollback is restored untouched on
+     * leaveAltScreen() (or cleanUp()). Idempotent.
+     */
+    public function enterAltScreen(): void
+    {
+        if ($this->inAltScreen) {
+            return;
+        }
+
+        $this->inAltScreen = true;
+        $this->activeOutput()->write("\033[?1049h", false, OutputInterface::OUTPUT_RAW);
+    }
+
+    /** Leaves the alternate screen buffer, restoring prior terminal content. */
+    public function leaveAltScreen(): void
+    {
+        if (!$this->inAltScreen) {
+            return;
+        }
+
+        $this->inAltScreen = false;
+        $this->activeOutput()->write("\033[?1049l", false, OutputInterface::OUTPUT_RAW);
+    }
+
+    /** Moves the cursor to an absolute (column, row) position. */
+    public function moveCursor(int $column, int $row): void
+    {
+        $this->activeCursor()->moveToPosition($column, $row);
+    }
+
+    /** Moves the cursor to the top-left origin (0, 0). */
+    public function cursorHome(): void
+    {
+        $this->activeCursor()->moveToPosition(0, 0);
     }
 
     /**
@@ -295,6 +346,11 @@ final class TerminalGui
         $this->cleanedUp = true;
         $this->cursor->show();
         $this->output->write("\033[0m");
+
+        if ($this->inAltScreen) {
+            $this->inAltScreen = false;
+            $this->output->write("\033[?1049l", false, OutputInterface::OUTPUT_RAW);
+        }
 
         if (self::isStreamResource($this->inputStream)) {
             self::setBlockingIfPossible($this->inputStream, true);

--- a/tests/phel/terminal-gui-test.phel
+++ b/tests/phel/terminal-gui-test.phel
@@ -1,6 +1,6 @@
 (ns phel-cli-gui-test.terminal-gui-test
   (:require phel.test :refer [deftest is testing])
-  (:require phel-cli-gui.terminal-gui :refer [parse-key]))
+  (:require phel-cli-gui.terminal-gui :refer [parse-key color->sgr]))
 
 ;; Pure-logic tests. GUI-side-effect functions are exercised from PHP.
 
@@ -35,3 +35,22 @@
 
 (deftest parse-key-unknown-escape-sequence-returns-raw-map
   (is (= {:char "\e[Z"} (parse-key {:raw "\e[Z" :hex "1b5b5a"}))))
+
+(deftest color->sgr-builds-256-colour-parameters
+  (is (= "38;5;196" (color->sgr {:fg-256 196})))
+  (is (= "48;5;52" (color->sgr {:bg-256 52})))
+  (is (= "38;5;196;48;5;52" (color->sgr {:fg-256 196 :bg-256 52}))))
+
+(deftest color->sgr-builds-truecolor-parameters
+  (is (= "38;2;255;128;0" (color->sgr {:fg-rgb [255 128 0]})))
+  (is (= "48;2;10;20;30" (color->sgr {:bg-rgb [10 20 30]}))))
+
+(deftest color->sgr-appends-option-codes
+  (testing "named options map to their SGR codes"
+           (is (= "38;5;196;1" (color->sgr {:fg-256 196 :options ["bold"]})))
+           (is (= "1;4" (color->sgr {:options ["bold" "underline"]})))
+           (is (= "4" (color->sgr {:options ["underscore"]})))))
+
+(deftest color->sgr-empty-spec-is-empty-string
+  (is (= "" (color->sgr {})))
+  (is (= "" (color->sgr {:options []}))))

--- a/tests/php/AnsiStyleTest.php
+++ b/tests/php/AnsiStyleTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelCliGui\Tests;
+
+use PhelCliGui\AnsiStyle;
+use PHPUnit\Framework\TestCase;
+
+final class AnsiStyleTest extends TestCase
+{
+    public function test_apply_wraps_text_in_the_sgr_sequence(): void
+    {
+        $style = new AnsiStyle('38;5;196');
+
+        self::assertSame("\033[38;5;196mboom\033[0m", $style->apply('boom'));
+    }
+
+    public function test_apply_with_empty_sgr_returns_text_unchanged(): void
+    {
+        $style = new AnsiStyle('');
+
+        self::assertSame('plain', $style->apply('plain'));
+    }
+}

--- a/tests/php/TerminalGuiTest.php
+++ b/tests/php/TerminalGuiTest.php
@@ -312,4 +312,68 @@ final class TerminalGuiTest extends TestCase
 
         self::assertStringContainsString("\033[31;1mboom\033[39;22m", $this->output->fetch());
     }
+
+    public function test_add_ansi_style_renders_256_colour_sequence(): void
+    {
+        $this->gui->addAnsiStyle('lava', '38;5;196;48;5;52');
+        $this->gui->render(0, 0, 'x', 'lava');
+
+        // Text stays clean; the escape wraps it and bounds use the clean text.
+        self::assertStringContainsString("\033[38;5;196;48;5;52mx\033[0m", $this->output->fetch());
+        self::assertSame(0, $this->gui->getMaxWidth());
+    }
+
+    public function test_enter_alt_screen_emits_sequence_once(): void
+    {
+        $this->gui->enterAltScreen();
+        $this->gui->enterAltScreen(); // idempotent
+
+        self::assertSame(1, substr_count($this->output->fetch(), "\033[?1049h"));
+    }
+
+    public function test_leave_alt_screen_emits_restore_sequence(): void
+    {
+        $this->gui->enterAltScreen();
+        $this->output->fetch();
+
+        $this->gui->leaveAltScreen();
+        self::assertStringContainsString("\033[?1049l", $this->output->fetch());
+    }
+
+    public function test_leave_alt_screen_without_enter_is_noop(): void
+    {
+        $this->gui->leaveAltScreen();
+
+        self::assertStringNotContainsString("\033[?1049l", $this->output->fetch());
+    }
+
+    public function test_cleanup_leaves_alt_screen(): void
+    {
+        // cleanUp only runs on the registered singleton, so build one.
+        TerminalGui::resetInstance();
+        $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+        $gui = TerminalGui::getInstance($this->inputStream, $output, new Cursor($output), false);
+        $output->fetch(); // drain init
+
+        $gui->enterAltScreen();
+        $output->fetch();
+
+        TerminalGui::resetInstance(); // triggers cleanUp on the singleton
+        self::assertStringContainsString("\033[?1049l", $output->fetch());
+    }
+
+    public function test_move_cursor_emits_absolute_position(): void
+    {
+        $this->gui->moveCursor(3, 2);
+
+        // Symfony Cursor::moveToPosition(col, row) emits "\e[{row+1};{col}H".
+        self::assertStringContainsString("\033[3;3H", $this->output->fetch());
+    }
+
+    public function test_cursor_home_moves_to_origin(): void
+    {
+        $this->gui->cursorHome();
+
+        self::assertStringContainsString("\033[1;0H", $this->output->fetch());
+    }
 }


### PR DESCRIPTION
Rendering primitives inspired by the [phel-doom](https://github.com/Chemaclass/phel-doom) terminal renderer — the pieces this library was missing for full-screen games and rich UIs.

## Added

### 256-color & truecolor
`add-color` registers a named style from the xterm-256 palette or 24-bit RGB, usable in any render call:

```phel
(add-color {:style-name "lava"  :fg-256 196 :bg-256 52 :options ["bold"]})
(add-color {:style-name "ocean" :fg-rgb [120 180 255]})
(render 0 0 "molten" "lava")
```

Backed by a new `AnsiStyle` (an `OutputFormatterStyleInterface` carrying a raw SGR string), so styled text stays clean and **render bounds remain correct**. The pure `color->sgr` helper is exposed for building sequences directly.

### Full-screen
`enter-alt-screen` / `leave-alt-screen` + the `with-screen` macro (alt screen + hidden cursor, restored on exit even on throw). The alt screen is also left on `cleanup-gui` / shutdown, so a crash never strands the user on a blank page.

### Cursor & input
- `move-cursor` / `cursor-home` for phel-doom's overwrite-in-place frame model (repaint without a flickering full clear).
- `read-available` drains all pending stdin bytes in one read for held-key responsiveness.

All new draw/cursor/screen ops route through the buffered-frame target, so they compose with `with-frame`.

## Test plan
- `composer build`, `composer format`, `composer validate --strict` clean.
- 28 Phel tests (`color->sgr` 256/RGB/options/empty) + 52 PHPUnit (was 37): `AnsiStyle` unit, 256-color render path keeps bounds, alt-screen enter/leave/idempotent/no-op/cleanup, move-cursor/cursor-home ANSI.

## Notes
Bundles the four primitives selected from the phel-doom-inspired set. Immediate mode and all existing APIs are unchanged.