### PR TITLE
chore: manage AI assistant config with agnostic-ai

### DIFF
--- a/.agnostic-ai/overlays/claude.settings.json
+++ b/.agnostic-ai/overlays/claude.settings.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "includeCoAuthoredBy": false
+}

--- a/.agnostic-ai/rules/project-conventions.md
+++ b/.agnostic-ai/rules/project-conventions.md
@@ -1,0 +1,31 @@
+---
+name: project-conventions
+description: Build, test and language conventions for the phel-cli-gui library.
+globs: "**/*"
+alwaysApply: true
+---
+
+`phel-cli-gui` is a terminal-rendering library written in [Phel](https://phel-lang.org/)
+(a Lisp that compiles to PHP) over Symfony Console's `Cursor`.
+
+## Layout
+
+- `src/phel/terminal-gui.phel` — the public Phel API.
+- `src/php/` — PHP classes (`PhelCliGui\` PSR-4): `TerminalGui` (Symfony wrapper + singleton), plus pure helpers `TerminalCanvas`, `BorderStyle`, `Text`, `AnsiStyle`.
+- `tests/phel/` — pure-logic Phel tests; `tests/php/` — PHPUnit tests that exercise rendering via `BufferedOutput`.
+
+## Toolchain
+
+- PHP `>=8.4`, `phel-lang/phel-lang` `^0.44` only.
+- Build: `composer build`. Test: `composer test` (Phel + PHPUnit). Format: `composer format`.
+- Run all three plus `composer validate --strict` before opening a PR; CI gates pushes on PHP 8.4 and 8.5.
+
+## Phel style (0.44)
+
+- Dot-separated namespaces — `phel.test`, `Symfony.Component.Console.Terminal`, `phel-cli-gui.terminal-gui` (not backslash).
+- Use the `php/new` interop form, not bare `new`.
+- Keep GUI side effects in PHP; cover pure helpers (`parse-key`, `color->sgr`) with Phel unit tests.
+
+## Commits
+
+- Conventional Commits; use `ref:` (not `refactor:`). No tooling/attribution trailers in messages.

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,14 @@ out/
 phel-config-local.php
 gacela-local.php
 local.phel
+
+# >>> agnostic-ai (managed) >>>
+# Generated paths. Edit specs, not this block. Run `agnostic-ai sync` to refresh.
+/.agnostic-ai/.sync-state
+/.agnostic-ai/AGNOSTIC_AI.md
+/.agnostic-ai/packs/
+/.claude/
+/AGENTS.md
+/CLAUDE.md
+/agnostic-ai.local.yaml
+# <<< agnostic-ai (managed) <<<

--- a/README.md
+++ b/README.md
@@ -98,6 +98,20 @@ tests/
   php/                      PHPUnit tests exercising the rendering layer
 ```
 
+## AI assistant config
+
+AI-assistant instructions are managed with [agnostic-ai](https://github.com/Chemaclass/agnostic-ai):
+the single source of truth lives under `.agnostic-ai/` and is transpiled to each
+tool's native files (`CLAUDE.md`, `AGENTS.md`, `.claude/…`), which are generated
+and git-ignored.
+
+```bash
+agnostic-ai sync          # regenerate per-target files after editing specs
+agnostic-ai sync --check  # CI gate: fail if outputs drift from specs
+```
+
+Edit specs in `.agnostic-ai/`, never the generated files.
+
 ## License
 
 MIT © [Jose M Valera Reales](https://chemaclass.com)

--- a/agnostic-ai.yaml
+++ b/agnostic-ai.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Chemaclass/agnostic-ai/main/docs/schemas/config.schema.json
+version: 1
+
+sources:
+  agents: .agnostic-ai/agents
+  skills: .agnostic-ai/skills
+  rules: .agnostic-ai/rules
+  hooks: .agnostic-ai/hooks
+  mcps: .agnostic-ai/mcps
+  commands: .agnostic-ai/commands
+
+targets:
+  - claude
+  - codex
+
+on-unsupported: warn
+
+gitignore:
+  enabled: true


### PR DESCRIPTION
Sets up [agnostic-ai](https://github.com/Chemaclass/agnostic-ai) as the single source of truth for AI-assistant config, targeting **claude** and **codex**.

## What

- `agnostic-ai init` (targets: claude, codex) + `import claude` — seeded `.agnostic-ai/overlays/claude.settings.json` from the existing `.claude/settings.json`.
- Added a real `project-conventions` rule (`.agnostic-ai/rules/`) capturing the build/test toolchain, layout, Phel 0.44 style, and commit conventions — so the generated `CLAUDE.md` / `AGENTS.md` carry meaningful content.
- `agnostic-ai sync` emits per-target files; they are **git-ignored** (managed block) so specs stay the only source edited.
- README documents the `agnostic-ai sync` / `sync --check` workflow.

## Verified
- `agnostic-ai validate`, `lint`, and `doctor` all pass; `status` reports in-sync.
- Generated `CLAUDE.md` / `AGENTS.md` / `.claude/rules/` are ignored, not committed; only specs + overlay + config + `.gitignore` + README are tracked.

## Notes
Follows the tool's recommended model (edit specs, regenerate outputs). Contributors run `agnostic-ai sync` after editing `.agnostic-ai/`.