### PR TITLE
ci: add PHPStan level 9 static analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Build
         run: composer build
 
+      - name: Static analysis
+        run: composer phpstan
+
       - name: Test
         run: composer test
 

--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,12 @@
         "symfony/console": "^7.4"
     },
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "require-dev": {
         "phpunit/phpunit": "^10.5",
         "roave/security-advisories": "dev-latest",
-        "symfony/var-dumper": "^7.4"
+        "symfony/var-dumper": "^7.4",
+        "phpstan/phpstan": "^2.1"
     },
     "autoload": {
         "psr-4": {
@@ -54,6 +56,7 @@
         ],
         "test:phel": "vendor/bin/phel test",
         "test:php": "vendor/bin/phpunit tests",
+        "phpstan": "vendor/bin/phpstan analyse",
         "format": "vendor/bin/phel format"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc159c4e828fa0c4265c8734135a2a2b",
+    "content-hash": "4adaa46f9e7c67914f1e43ade7eea8c3",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1457,6 +1457,70 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.2.2",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e5cc34d491a90e79c216d824f60fe21fd4d93bd6",
+                "reference": "e5cc34d491a90e79c216d824f60fe21fd4d93bd6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-05T09:00:01+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4195,7 +4259,7 @@
     "stability-flags": {
         "roave/security-advisories": 20
     },
-    "prefer-stable": false,
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.4",

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,0 +1,9 @@
+parameters:
+    level: 9
+    paths:
+        - src/php
+        - tests/php
+    # A PHPDoc `resource` is not a runtime guarantee — a stream can be closed
+    # (is_resource() === false) without changing its static type, so the
+    # defensive is_resource()/posix_isatty() guards are not redundant.
+    treatPhpDocTypesAsCertain: false

--- a/src/php/AnsiStyle.php
+++ b/src/php/AnsiStyle.php
@@ -37,6 +37,7 @@ final class AnsiStyle implements OutputFormatterStyleInterface
     {
     }
 
+    /** @param string[] $options */
     public function setOptions(array $options): void
     {
     }

--- a/src/php/ScreenBuffer.php
+++ b/src/php/ScreenBuffer.php
@@ -18,10 +18,10 @@ use InvalidArgumentException;
  */
 final class ScreenBuffer
 {
-    /** @var list<string> one glyph per cell, blank = ' ' */
+    /** @var array<int, string> one glyph per cell, blank = ' ', indexed row*width+column */
     private array $chars;
 
-    /** @var list<?string> style name per cell, null = unstyled */
+    /** @var array<int, ?string> style name per cell, null = unstyled, indexed row*width+column */
     private array $styles;
 
     public function __construct(

--- a/src/php/TerminalGui.php
+++ b/src/php/TerminalGui.php
@@ -27,6 +27,7 @@ final class TerminalGui
 
     private static ?self $instance = null;
 
+    /** @param resource $inputStream */
     public static function getInstance(
         $inputStream = STDIN,
         ?OutputInterface $output = null,
@@ -41,6 +42,7 @@ final class TerminalGui
         );
     }
 
+    /** @param resource $inputStream */
     public static function withStream(
         $inputStream = STDIN,
         ?OutputInterface $output = null,
@@ -500,6 +502,9 @@ final class TerminalGui
             $this->output->write("\033[?1049l", false, OutputInterface::OUTPUT_RAW);
         }
 
+        // Guards against an already-closed stream: at shutdown the input may be
+        // a closed resource (is_resource() === false), which restoreSttyMode's
+        // posix_isatty() would choke on.
         if (self::isStreamResource($this->inputStream)) {
             self::setBlockingIfPossible($this->inputStream, true);
             $this->restoreSttyMode();
@@ -545,6 +550,8 @@ final class TerminalGui
 
     /**
      * @param resource|mixed $stream
+     *
+     * @phpstan-assert-if-true resource $stream
      */
     private static function isStreamResource($stream): bool
     {

--- a/src/php/Text.php
+++ b/src/php/Text.php
@@ -12,11 +12,10 @@ final class Text
             return $fallback;
         }
 
-        $char = function_exists('mb_substr')
+        // $value is non-empty, so the first character is always non-empty too.
+        return function_exists('mb_substr')
             ? mb_substr($value, 0, 1)
             : substr($value, 0, 1);
-
-        return $char === '' ? $fallback : $char;
     }
 
     /**

--- a/tests/php/FrameSessionTest.php
+++ b/tests/php/FrameSessionTest.php
@@ -39,7 +39,9 @@ final class FrameSessionTest extends TestCase
     {
         $frame = new FrameSession();
         $frame->begin($this->base());
-        $frame->output()->write('hello', false, OutputInterface::OUTPUT_RAW);
+        $output = $frame->output();
+        self::assertNotNull($output);
+        $output->write('hello', false, OutputInterface::OUTPUT_RAW);
 
         self::assertSame('hello', $frame->end(0, 0));
         self::assertFalse($frame->isActive());
@@ -58,7 +60,9 @@ final class FrameSessionTest extends TestCase
         $frame = new FrameSession();
         $frame->begin($this->base());
         $frame->begin($this->base()); // inner — ignored, depth bump only
-        $frame->output()->write('x', false, OutputInterface::OUTPUT_RAW);
+        $output = $frame->output();
+        self::assertNotNull($output);
+        $output->write('x', false, OutputInterface::OUTPUT_RAW);
 
         self::assertNull($frame->end(0, 0)); // inner close: no flush
         self::assertTrue($frame->isActive());

--- a/tests/php/TerminalGuiTest.php
+++ b/tests/php/TerminalGuiTest.php
@@ -25,7 +25,9 @@ final class TerminalGuiTest extends TestCase
     protected function setUp(): void
     {
         $this->output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
-        $this->inputStream = fopen('php://memory', 'rb');
+        $stream = fopen('php://memory', 'rb');
+        self::assertNotFalse($stream);
+        $this->inputStream = $stream;
 
         $this->gui = TerminalGui::withStream(
             inputStream: $this->inputStream,


### PR DESCRIPTION
Adds PHPStan level 9 over \`src/php\` and \`tests/php\`, wired into the \`composer phpstan\` script and CI.

## What

- New \`phpstan/phpstan\` dev dep (pinned stable \`^2.1\`, \`prefer-stable\` enabled) + \`phpstan.dist.neon\` (level 9).
- CI gains a **Static analysis** step in the build-and-test job.
- All 13 findings fixed at the root (no \`@phpstan-ignore\`, baseline, or casts):
  - \`Text::firstChar\` drops an unreachable empty-string branch.
  - \`AnsiStyle::setOptions\` documents its array value type.
  - \`ScreenBuffer\` cell stores typed \`array<int, ..>\` (written by computed index), not \`list\`.
  - \`TerminalGui\` static factories document the \`resource\` param; \`isStreamResource\` narrows via \`@phpstan-assert-if-true\`.
  - Tests narrow nullable \`output()\` and \`fopen()\` results.
- \`treatPhpDocTypesAsCertain: false\` — a PHPDoc \`resource\` is not a runtime guarantee (a stream can close), so the cleanup guards are genuinely not redundant.

## Verify

\`composer phpstan\` → no errors · \`composer test\` → 28 Phel + 105 PHPUnit green · no behavior change.